### PR TITLE
Wrong shotName if shotName = None in editShot()

### DIFF
--- a/Prism/Scripts/ProjectScripts/ProjectBrowser.py
+++ b/Prism/Scripts/ProjectScripts/ProjectBrowser.py
@@ -2945,10 +2945,6 @@ class ProjectBrowser(QMainWindow, ProjectBrowser_ui.Ui_mw_ProjectBrowser):
             if sName != "no sequence":
                 sequs.append(sName)
 
-        if not shotName:
-            shotName, seqName = self.core.entities.splitShotname(self.cursShots)
-            shotName = seqName + self.core.sequenceSeparator
-
         try:
             del sys.modules["EditShot"]
         except:


### PR DESCRIPTION
This piece of code makes the shotName variable end up being "no sequence-" if the shotName variable was None.
This doesn't make sense why it should return "no sequence-". Alsoit breaks the editShot_open function in the shotgun plugin as it expects to get None back if the shotName is None.