### PR TITLE
Small Linux compatibility changes

### DIFF
--- a/Prism/Plugins/Apps/Blender/Scripts/Prism_Blender_Integration.py
+++ b/Prism/Plugins/Apps/Blender/Scripts/Prism_Blender_Integration.py
@@ -65,7 +65,7 @@ class Prism_Blender_Integration(object):
         if platform.system() == "Windows":
             self.examplePath = self.getBlenderPath() or "C:/Program Files/Blender Foundation/Blender 2.82/"
         elif platform.system() == "Linux":
-            self.examplePath = "/usr/local/blender-2.79b-linux-glibc219-x86_64/2.79"
+            self.examplePath = self.getBlenderPath()
         elif platform.system() == "Darwin":
             self.examplePath = "/Applications/blender/blender.app/Resources/2.79"
 
@@ -79,25 +79,33 @@ class Prism_Blender_Integration(object):
 
     @err_catcher(name=__name__)
     def getBlenderPath(self):
-        try:
-            key = _winreg.OpenKey(
-                _winreg.HKEY_LOCAL_MACHINE,
-                "SOFTWARE\\Classes\\blendfile\\shell\\open\\command",
-                0,
-                _winreg.KEY_READ | _winreg.KEY_WOW64_64KEY,
-            )
-            blenderPath = (
-                (_winreg.QueryValueEx(key, ""))[0].split(' "%1"')[0].replace('"', "")
-            )
+        if platform.system() == "Windows":
+            try:
+                key = _winreg.OpenKey(
+                    _winreg.HKEY_LOCAL_MACHINE,
+                    "SOFTWARE\\Classes\\blendfile\\shell\\open\\command",
+                    0,
+                    _winreg.KEY_READ | _winreg.KEY_WOW64_64KEY,
+                )
+                blenderPath = (
+                    (_winreg.QueryValueEx(key, ""))[0].split(' "%1"')[0].replace('"', "")
+                )
 
-            vpath = os.path.join(os.path.dirname(blenderPath), "2.81")
+                vpath = os.path.join(os.path.dirname(blenderPath), "2.81")
 
-            if os.path.exists(vpath):
-                return vpath
-            else:
+                if os.path.exists(vpath):
+                    return vpath
+                else:
+                    return ""
+
+            except:
                 return ""
-
-        except:
+        elif platform.system() == "Linux":
+            for location in ["/usr/share/blender", "/opt/blender2.93",
+                             "/opt/blender2.92", "/usr/local/blender-2.79b-linux-glibc219-x86_64/2.79"]:
+                if os.path.exists(location):
+                    return location
+        else:
             return ""
 
     def addIntegration(self, installPath):
@@ -333,7 +341,7 @@ class Prism_Blender_Integration(object):
             if platform.system() == "Windows":
                 blenderPath = self.getBlenderPath()
             elif platform.system() == "Linux":
-                blenderPath = "/usr/local/blender-2.79b-linux-glibc219-x86_64/2.79"
+                blenderPath = self.getBlenderPath()
             elif platform.system() == "Darwin":
                 blenderPath = "/Applications/blender/blender.app/Resources/2.79"
 

--- a/Prism/Plugins/Apps/Houdini/Scripts/Prism_Houdini_Integration.py
+++ b/Prism/Plugins/Apps/Houdini/Scripts/Prism_Houdini_Integration.py
@@ -70,30 +70,41 @@ class Prism_Houdini_Integration(object):
             defaultpath = os.path.join(self.getHoudiniPath(), "bin", "houdini.exe")
             if os.path.exists(defaultpath):
                 execPath = defaultpath
+        elif platform.system() == "Linux":
+            defaultpath = os.path.join(self.getHoudiniPath(), "bin", "houdini")
+            if os.path.exists(defaultpath):
+                execPath = defaultpath
 
         return execPath
 
     @err_catcher(name=__name__)
     def getHoudiniPath(self):
-        try:
-            key = _winreg.OpenKey(
-                _winreg.HKEY_LOCAL_MACHINE,
-                "SOFTWARE\\Side Effects Software",
-                0,
-                _winreg.KEY_READ | _winreg.KEY_WOW64_64KEY,
-            )
-            validVersion = (_winreg.QueryValueEx(key, "ActiveVersion"))[0]
+        if platform.system() == "Windows":
+            try:
+                key = _winreg.OpenKey(
+                    _winreg.HKEY_LOCAL_MACHINE,
+                    "SOFTWARE\\Side Effects Software",
+                    0,
+                    _winreg.KEY_READ | _winreg.KEY_WOW64_64KEY,
+                )
+                validVersion = (_winreg.QueryValueEx(key, "ActiveVersion"))[0]
 
-            key = _winreg.OpenKey(
-                _winreg.HKEY_LOCAL_MACHINE,
-                "SOFTWARE\\Side Effects Software\\Houdini " + validVersion,
-                0,
-                _winreg.KEY_READ | _winreg.KEY_WOW64_64KEY,
-            )
+                key = _winreg.OpenKey(
+                    _winreg.HKEY_LOCAL_MACHINE,
+                    "SOFTWARE\\Side Effects Software\\Houdini " + validVersion,
+                    0,
+                    _winreg.KEY_READ | _winreg.KEY_WOW64_64KEY,
+                )
 
-            return (_winreg.QueryValueEx(key, "InstallPath"))[0]
+                return (_winreg.QueryValueEx(key, "InstallPath"))[0]
 
-        except:
+            except:
+                return ""
+        elif platform.system() == "Linux":
+            for p in glob.glob("/opt/hfs*"):
+                if os.path.exists(p):
+                    return p
+        else:
             return ""
 
     @err_catcher(name=__name__)

--- a/Prism/Scripts/PrismCore.py
+++ b/Prism/Scripts/PrismCore.py
@@ -64,25 +64,25 @@ if not prismLibs:
     prismLibs = prismRoot
 
 if not os.path.exists(os.path.join(prismLibs, "PythonLibs")):
-    raise Exception("Prism: Couldn't find libraries. Set \"PRISM_LIBS\" to fix this.")
+    print("Prism: Couldn't find distributed libraries. Set \"PRISM_LIBS\" to fix this.")
+else:
+	pyLibPath = os.path.join(prismLibs, "PythonLibs", pyLibs)
+	cpLibs = os.path.join(prismLibs, "PythonLibs", "CrossPlatform")
+
+	if cpLibs not in sys.path:
+		sys.path.append(cpLibs)
+
+	if pyLibPath not in sys.path:
+		sys.path.append(pyLibPath)
+
+	if platform.system() == "Windows":
+		sys.path.insert(0, os.path.join(pyLibPath, "win32"))
+		sys.path.insert(0, os.path.join(pyLibPath, "win32", "lib"))
+		os.environ['PATH'] = os.path.join(pyLibPath, "pywin32_system32") + os.pathsep + os.environ['PATH']
 
 scriptPath = os.path.join(prismRoot, "Scripts")
 if scriptPath not in sys.path:
     sys.path.append(scriptPath)
-
-pyLibPath = os.path.join(prismLibs, "PythonLibs", pyLibs)
-cpLibs = os.path.join(prismLibs, "PythonLibs", "CrossPlatform")
-
-if cpLibs not in sys.path:
-    sys.path.append(cpLibs)
-
-if pyLibPath not in sys.path:
-    sys.path.append(pyLibPath)
-
-if platform.system() == "Windows":
-    sys.path.insert(0, os.path.join(pyLibPath, "win32"))
-    sys.path.insert(0, os.path.join(pyLibPath, "win32", "lib"))
-    os.environ['PATH'] = os.path.join(pyLibPath, "pywin32_system32") + os.pathsep + os.environ['PATH']
 
 guiPath = os.path.join(prismRoot, "Scripts", "UserInterfacesPrism")
 if guiPath not in sys.path:

--- a/Prism/Scripts/PrismSettings.py
+++ b/Prism/Scripts/PrismSettings.py
@@ -348,8 +348,8 @@ class PrismSettings(QDialog, PrismSettings_ui.Ui_dlg_PrismSettings):
 
             cData["localfiles"][self.core.projectName] = lpath
 
-        if self.e_localPath.text() != "disabled":
-            self.core.localProjectPath = lpath
+            if self.e_localPath.text() != "disabled":
+                self.core.localProjectPath = lpath
 
         if hasattr(self.core, "projectName"):
             useLocal = [x for x in self.useLocalStates if self.useLocalStates[x] == self.cb_userUseLocal.currentText()][0]


### PR DESCRIPTION
On Linux one can usually rely on the system libraries, e.g. for PySide.
This guarantees better compatibility because distributed libraries can easily become outdated.
Therefore I make the existence of PythonLibs optional. It works fine, tested it a bit so far.
Also the default paths where Blender and Houdini are searched on Linux has been updated.